### PR TITLE
Change docker run in README.md

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -165,5 +165,5 @@ bentoml containerize iris_classifier:latest
 
 Test out the docker image built:
 ```bash
-docker run iris_classifier:invwzzsw7li6zckb2ie5eubhd -p 5000:5000
+docker run -p 5000:5000 iris_classifier:invwzzsw7li6zckb2ie5eubhd 
 ```


### PR DESCRIPTION
Running `docker run iris_classifier:invwzzsw7li6zckb2ie5eubhd -p 5000:5000` willl give an error:
```bash
Usage: bentoml serve [OPTIONS] BENTO
Try 'bentoml serve --help' for help.

Error: No such option: -p
```
Change this command to `docker run -p 5000:5000 iris_classifier:invwzzsw7li6zckb2ie5eubhd` fixed the issue.