### PR TITLE
Update requirements.txt

### DIFF
--- a/quickstart/requirements.txt
+++ b/quickstart/requirements.txt
@@ -1,3 +1,4 @@
 scikit-learn
 pandas
 bentoml>=1.0.0a
+ipykernel


### PR DESCRIPTION
ipykernel is required to run iris_classifier.ipynb. I tried running this tutorial by cloning it locally and installing requirements. I ran it in VSCode, so I don't think the absence of jupyter-lab was critical, although adding it also might be helpful to users using jupyter notebooks and jupyter lab.